### PR TITLE
Properly implement DM room creation & retrieval

### DIFF
--- a/examples/a simple bot/simple.py
+++ b/examples/a simple bot/simple.py
@@ -6,6 +6,7 @@ So, make sure you've got an interactive session on first run.
 
 This example was written in nio-bot version 1.1.0b2.
 """
+
 import getpass
 from base64 import b16decode, b16encode
 from configparser import ConfigParser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,19 +96,19 @@ filterwarnings = [
 [tool.ruff]
 # Replacement for isort & black
 exclude = [".git"]
-ignore = ["F403", "F405"]
 target-version = "py39"
 line-length = 120
 indent-width = 4
 respect-gitignore = true
+
+[tool.ruff.lint]
+fixable = ["ALL"]
+ignore =   ["F403", "F405"]
 select = [
     "E",     # pycodestyle
     "F",     # Pyflakes
     "I001",  # isort
 ]
-
-[tool.ruff.lint]
-fixable = ["ALL"]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.
@@ -121,11 +121,11 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 case-sensitive = true
 combine-as-imports = true
 detect-same-package = true
 
-[tool.ruff.pycodestyle]
+[tool.ruff.lint.pycodestyle]
 max-doc-length = 120
 max-line-length = 120

--- a/src/niobot/attachment.py
+++ b/src/niobot/attachment.py
@@ -17,15 +17,14 @@ import time
 import typing
 import urllib.parse
 import warnings
-from typing import Union as U
-from typing import overload
+from typing import Union as U, overload
 
+import PIL.Image
 import aiofiles
 import aiohttp
 import blurhash
 import magic
 import nio
-import PIL.Image
 
 from .exceptions import (
     MediaCodecWarning,
@@ -340,7 +339,9 @@ def _size(file: U[pathlib.Path, io.BytesIO]) -> int:
     return file.stat().st_size
 
 
-def which(file: U[io.BytesIO, pathlib.Path, str], mime_type: typing.Optional[str] = None) -> U[
+def which(
+    file: U[io.BytesIO, pathlib.Path, str], mime_type: typing.Optional[str] = None
+) -> U[
     typing.Type["FileAttachment"],
     typing.Type["ImageAttachment"],
     typing.Type["AudioAttachment"],
@@ -1100,9 +1101,7 @@ class VideoAttachment(BaseAttachment):
                     if stream["codec_type"] == "video":
                         if stream["codec_name"].lower() not in SUPPORTED_VIDEO_CODECS or not stream[
                             "codec_name"
-                        ].startswith(
-                            "pcm_"
-                        ):  # usually, pcm is supported.
+                        ].startswith("pcm_"):  # usually, pcm is supported.
                             warning = MediaCodecWarning(stream["codec_name"], *SUPPORTED_VIDEO_CODECS)
                             warnings.warn(warning)
                         height = stream["height"]

--- a/src/niobot/client.py
+++ b/src/niobot/client.py
@@ -774,20 +774,20 @@ class NioBot(nio.AsyncClient):
         )
         if isinstance(result, nio.RoomCreateError):
             raise GenericMatrixError("Failed to create DM room", response=result)
-        
-        dm_rooms = {}
-        dm_rooms[user_id] = [result.room_id]
+
+        dm_rooms = {user_id: [result.room_id]}
 
         logging.debug(f"create_dm_user: user_id {user_id} self.user_id {self.user_id}")
         # Trying to send m.direct type eventfrom nio.responses import DirectRoomsErrorResponse, DirectRoomsResponse
         logging.debug(f"create_dm_user: setting m.direct type with rooms {nio.Api.to_json(dm_rooms)}")
         await self._send(
             nio.DirectRoomsResponse,
-            'PUT',
-            nio.Api._build_path(    ["user", self.user_id, "account_data", "m.direct"],
-                                    {"access_token": self.access_token},
+            "PUT",
+            nio.Api._build_path(
+                ["user", self.user_id, "account_data", "m.direct"],
+                {"access_token": self.access_token},
             ),
-            nio.Api.to_json( dm_rooms )
+            nio.Api.to_json(dm_rooms),
         )
 
         return result
@@ -823,6 +823,7 @@ class NioBot(nio.AsyncClient):
         :return: The response from the server.
         :raises MessageException: If the message fails to send, or if the file fails to upload.
         :raises ValueError: You specified neither file nor content.
+        :raises RuntimeError: An internal error occured. A room was created, but is not in the bot room list.
         """
         if file and BaseAttachment is None:
             raise ValueError("You are missing required libraries to use attachments.")
@@ -833,8 +834,8 @@ class NioBot(nio.AsyncClient):
             _user = room
             room = None
             rooms = await self.get_dm_rooms(_user)
-            logging.debug( f"send_message get_dm_rooms returns rooms {nio.Api.to_json(rooms)}" )
-            
+            logging.debug(f"send_message get_dm_rooms returns rooms {nio.Api.to_json(rooms)}")
+
             if rooms:
                 for r_id in rooms:
                     if r_id in self.rooms:
@@ -986,7 +987,7 @@ class NioBot(nio.AsyncClient):
 
         :param room: The room the message is in.
         :param message: The event ID or message object to react to.
-        :param emoji: The emoji to react with (e.g. `\N{cross mark}` = ❌)
+        :param emoji: The emoji to react with (e.g. `\N{CROSS MARK}` = ❌)
         :return: The response from the server.
         :raises MessageException: If the message fails to react.
         """

--- a/src/tests/test_attachment.py
+++ b/src/tests/test_attachment.py
@@ -1,9 +1,8 @@
 import pathlib
 import typing
 
-import pytest
-
 import niobot
+import pytest
 
 ASSETS = pathlib.Path(__file__).parent / "assets"
 

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -1,9 +1,8 @@
 import re
 import typing
 
-import pytest
-
 import niobot
+import pytest
 
 DEFAULT_HELP_COMMAND = niobot.Command(
     "help",

--- a/src/tests/test_parsers.py
+++ b/src/tests/test_parsers.py
@@ -1,7 +1,6 @@
 import typing
 
 import pytest
-
 from niobot.commands import Argument
 from niobot.context import Context
 from niobot.utils.parsers import *

--- a/src/tests/test_utils_unblocking.py
+++ b/src/tests/test_utils_unblocking.py
@@ -1,5 +1,4 @@
 import pytest
-
 from niobot.utils import unblocking
 
 


### PR DESCRIPTION
This is a bug fix for the send_message, get_dm_rooms, and create_dm_room functions.

I also added code to do a lazy check if there are rooms that are on the server, but not on the bot. I am not sure
why this is happening.

I added a call to set the m.direct type on the newly created dm_room. This is not really supported by
the nio-sdk library, which is missing the MDirectResponse type.